### PR TITLE
MD-107: Sync core lock settings on enable

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -53,8 +53,8 @@ class observer {
             // Ensure BigBlueButtonBN module is enabled when BNX is enabled.
             mod::enable_plugin('bigbluebuttonbn', 1);
 
-            // One-time migration from core lock settings into BNX lock settings.
-            bbbext_bnx_migrate_core_locksettings_data();
+            // Refresh core lock settings into BNX on every enable.
+            bbbext_bnx_sync_core_locksettings_data();
 
             // BNX owns reminders when enabled; force-disable legacy bnreminders.
             self::disable_bnreminders_if_enabled();

--- a/db/migration.php
+++ b/db/migration.php
@@ -133,6 +133,19 @@ function bbbext_bnx_migrate_core_locksettings_data(): void {
 }
 
 /**
+ * Synchronize core lock settings into BNX lock settings.
+ *
+ * This is intended for BNX enable events so that any core lock setting
+ * changes made while BNX was disabled are reflected in BNX immediately.
+ *
+ * @return void
+ */
+function bbbext_bnx_sync_core_locksettings_data(): void {
+    bbbext_bnx_migrate_core_locksettings_admin_config();
+    bbbext_bnx_migrate_core_locksettings_instance_settings(true);
+}
+
+/**
  * Migrate core lock admin defaults/editability into BNX config.
  *
  * @return void
@@ -178,9 +191,10 @@ function bbbext_bnx_migrate_core_locksettings_admin_config(): void {
 /**
  * Migrate existing activity lock values from core module columns into BNX settings.
  *
+ * @param bool $overwriteexisting When true, update existing BNX setting values.
  * @return void
  */
-function bbbext_bnx_migrate_core_locksettings_instance_settings(): void {
+function bbbext_bnx_migrate_core_locksettings_instance_settings(bool $overwriteexisting = false): void {
     global $DB;
 
     $mapping = [
@@ -209,12 +223,28 @@ function bbbext_bnx_migrate_core_locksettings_instance_settings(): void {
         }
 
         foreach ($mapping as $settingname => $meta) {
-            if ($DB->record_exists('bbbext_bnx_settings', ['bnxid' => $bnxid, 'name' => $settingname])) {
-                continue;
-            }
-
             $corevalue = (int)!empty($instance->{$meta['corefield']});
             $bnxvalue = !empty($meta['invert']) ? (int)!$corevalue : $corevalue;
+
+            $existing = $DB->get_record('bbbext_bnx_settings', [
+                'bnxid' => $bnxid,
+                'name' => $settingname,
+            ], 'id, value');
+
+            if ($existing) {
+                if (!$overwriteexisting) {
+                    continue;
+                }
+
+                if ((string)$existing->value !== (string)$bnxvalue) {
+                    $DB->update_record('bbbext_bnx_settings', (object)[
+                        'id' => $existing->id,
+                        'value' => (string)$bnxvalue,
+                        'timemodified' => $now,
+                    ]);
+                }
+                continue;
+            }
 
             $DB->insert_record('bbbext_bnx_settings', (object)[
                 'bnxid' => $bnxid,

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -102,11 +102,11 @@ function xmldb_bbbext_bnx_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026040101, 'bbbext', 'bnx');
     }
 
-    if ($oldversion < 2026040103) {
+    if ($oldversion < 2026050100) {
         // One-time migration from core lock settings into BNX lock settings.
         bbbext_bnx_migrate_core_locksettings_data();
 
-        upgrade_plugin_savepoint(true, 2026040103, 'bbbext', 'bnx');
+        upgrade_plugin_savepoint(true, 2026050100, 'bbbext', 'bnx');
     }
 
     return true;

--- a/tests/install_migration_test.php
+++ b/tests/install_migration_test.php
@@ -28,6 +28,7 @@ namespace bbbext_bnx;
  * @covers ::bbbext_bnx_migrate_core_locksettings_data
  * @covers ::bbbext_bnx_migrate_core_locksettings_admin_config
  * @covers ::bbbext_bnx_migrate_core_locksettings_instance_settings
+ * @covers ::bbbext_bnx_sync_core_locksettings_data
  * @package   bbbext_bnx
  * @copyright 2026 onwards, Blindside Networks Inc
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
@@ -265,6 +266,64 @@ final class install_migration_test extends \advanced_testcase {
         $this->assertSame('0', (string)get_config('bbbext_bnx', 'cam_default'));
         $this->assertSame('0', (string)get_config('bbbext_bnx', 'cam_editable'));
         $this->assertSame('1', (string)get_config('bbbext_bnx', 'locksettings_core_migrated'));
+    }
+
+    /**
+     * Core lock settings should be synchronized on enable without duplicating rows.
+     *
+     * @return void
+     */
+    public function test_sync_core_locksettings_updates_existing_values_without_duplicates(): void {
+        global $DB;
+
+        $course = $this->getDataGenerator()->create_course();
+        $bbb = $this->getDataGenerator()->create_module('bigbluebuttonbn', [
+            'course' => $course->id,
+            'disablecam' => 1,
+        ]);
+
+        // Existing BNX values (stale) that should be refreshed by sync.
+        $bnxid = $this->ensure_bnx_instance($bbb->id);
+        $existing = $DB->get_record('bbbext_bnx_settings', [
+            'bnxid' => $bnxid,
+            'name' => 'enablecam',
+        ], 'id');
+        if ($existing) {
+            $DB->set_field('bbbext_bnx_settings', 'value', '0', ['id' => $existing->id]);
+        } else {
+            $DB->insert_record('bbbext_bnx_settings', (object) [
+                'bnxid' => $bnxid,
+                'name' => 'enablecam',
+                'value' => '0',
+                'timecreated' => time(),
+                'timemodified' => time(),
+            ]);
+        }
+
+        // Simulate core changes while BNX is disabled.
+        $DB->set_field('bigbluebuttonbn', 'disablecam', 0, ['id' => $bbb->id]);
+        set_config('disablecam_default', 0, 'mod_bigbluebuttonbn');
+        set_config('disablecam_editable', 1, 'mod_bigbluebuttonbn');
+
+        bbbext_bnx_sync_core_locksettings_data();
+
+        $camsetting = $DB->get_record('bbbext_bnx_settings', [
+            'bnxid' => $bnxid,
+            'name' => 'enablecam',
+        ], '*', MUST_EXIST);
+
+        // Core disablecam=0 becomes BNX enablecam=1.
+        $this->assertSame('1', (string)$camsetting->value);
+
+        // Admin defaults/editability should also be refreshed.
+        $this->assertSame('1', (string)get_config('bbbext_bnx', 'cam_default'));
+        $this->assertSame('1', (string)get_config('bbbext_bnx', 'cam_editable'));
+
+        // No duplicate settings row should be created.
+        $this->assertSame(1, $DB->count_records('bbbext_bnx_settings', [
+            'bnxid' => $bnxid,
+            'name' => 'enablecam',
+        ]));
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component    = 'bbbext_bnx';
 $plugin->release      = '1.1-beta.1';
-$plugin->version      = 2026040103;
+$plugin->version      = 2026050100;
 $plugin->requires     = 2025100600; // Moodle 5.1.0 minimum.
 $plugin->supported    = [501, 502];
 $plugin->maturity     = MATURITY_BETA;


### PR DESCRIPTION
- Add enable-time sync so BNX re-imports current core lock settings when re-enabled
- Keep install/upgrade migration idempotent for first-time installs and upgrades
- Update existing BNX lock setting rows in place instead of duplicating them
- Add regression coverage for re-enable synchronization and non-duplicating updates